### PR TITLE
Generar carpetas para cada tipo de reporte ya sea mensual, por rango de fecha o anual

### DIFF
--- a/src/configuraciones/rutas.py
+++ b/src/configuraciones/rutas.py
@@ -1,6 +1,7 @@
 import os
 import sys
 from userpaths import get_my_documents
+from utilidades.tipos_reporte import TiposReporte
 
 
 def obtener_ruta_base():
@@ -19,13 +20,17 @@ def obtener_ruta_sesion_json() -> str:
     ruta_final_sesion_json = os.path.join(RUTA_BASE, ruta_absoluta_sesion_json)
     return ruta_final_sesion_json
 
-def obtener_ruta_reportes() -> str:
+def obtener_ruta_reportes(indice_opcion_tipo_reporte: str) -> str:
     ruta_documentos = get_my_documents()
     ruta_reportes = os.path.join(ruta_documentos, "REPORTES_SERVICIOS")
     
+    opcion_tipo_reporte = TiposReporte[f"{indice_opcion_tipo_reporte}"]
+    ruta_tipo_reporte = os.path.join(ruta_reportes, opcion_tipo_reporte.value)
+    
     try:
         os.makedirs(ruta_reportes, exist_ok = True)
-        return ruta_reportes
+        os.makedirs(ruta_tipo_reporte, exist_ok = True)
+        return ruta_tipo_reporte
     except OSError:
         return None
 

--- a/src/infraestructura/reportes/reporte_servicios.py
+++ b/src/infraestructura/reportes/reporte_servicios.py
@@ -9,22 +9,16 @@ from typing import Optional, List, Any
 
 from infraestructura.dependencias import contenedor_dependencias
 from utilidades.cargar_meses import cargar_mes
+from utilidades.tipos_reporte import TiposReporte
 from configuraciones.rutas import obtener_ruta_reportes
 from dominio.excepciones import ServicioValidacionError
 from infraestructura.reportes.reporte_base import ReporteBase
 
 
 SERVICIO_CONTROLADOR = contenedor_dependencias.obtener_servicio_controlador()
-OPCIONES_TIPO_REPORTE = [
-    "MENSUAL",
-    "RANGO_FECHA",
-    "ANUAL"
-]
+
 
 class ReporteServicios(ReporteBase):
-    def __init__(self):
-        self.RUTA_REPORTES_SERVICOS = obtener_ruta_reportes()
-    
     def crear_libro(self):
         libro = Workbook()
         return libro
@@ -135,20 +129,22 @@ class ReporteServicios(ReporteBase):
         fecha_hasta: Optional[date] = None,
         anio: Optional[date] = None
     ):
-        if (indice_opcion_tipo_reporte == OPCIONES_TIPO_REPORTE[0]):
+        opcion_tipo_reporte = TiposReporte[f"{indice_opcion_tipo_reporte}"].name
+        
+        if (opcion_tipo_reporte == "MENSUAL"):
             lista_dict_servicios_realizados = SERVICIO_CONTROLADOR.filtrar_reporte_servicios_controlador(
                 indice_opcion_tipo_reporte = indice_opcion_tipo_reporte,
                 mes_anio = mes_anio
             )
         
-        if (indice_opcion_tipo_reporte == OPCIONES_TIPO_REPORTE[1]):
+        if (opcion_tipo_reporte == "RANGO_FECHA"):
             lista_dict_servicios_realizados = SERVICIO_CONTROLADOR.filtrar_reporte_servicios_controlador(
                 indice_opcion_tipo_reporte = indice_opcion_tipo_reporte,
                 fecha_desde = fecha_desde,
                 fecha_hasta = fecha_hasta
             )
             
-        if (indice_opcion_tipo_reporte == OPCIONES_TIPO_REPORTE[2]):
+        if (opcion_tipo_reporte == "ANUAL"):
             lista_dict_servicios_realizados = SERVICIO_CONTROLADOR.filtrar_reporte_servicios_controlador(
                 indice_opcion_tipo_reporte = indice_opcion_tipo_reporte,
                 anio = anio
@@ -191,20 +187,22 @@ class ReporteServicios(ReporteBase):
         fecha_hasta: Optional[date] = None,
         anio: Optional[date] = None
     ):
-        if (indice_opcion_tipo_reporte == OPCIONES_TIPO_REPORTE[0]):
+        opcion_tipo_reporte = TiposReporte[f"{indice_opcion_tipo_reporte}"].name
+        
+        if (opcion_tipo_reporte == "MENSUAL"):
             lista_dict_tipos_servicios_realizados = SERVICIO_CONTROLADOR.conteo_tipos_servicios_realizados_controlador(
                 indice_opcion_tipo_reporte = indice_opcion_tipo_reporte,
                 mes_anio = mes_anio
             )
             
-        if (indice_opcion_tipo_reporte == OPCIONES_TIPO_REPORTE[1]):
+        if (opcion_tipo_reporte == "RANGO_FECHA"):
             lista_dict_tipos_servicios_realizados = SERVICIO_CONTROLADOR.conteo_tipos_servicios_realizados_controlador(
                 indice_opcion_tipo_reporte = indice_opcion_tipo_reporte,
                 fecha_desde = fecha_desde,
                 fecha_hasta = fecha_hasta
             )
         
-        if (indice_opcion_tipo_reporte == OPCIONES_TIPO_REPORTE[2]):
+        if (opcion_tipo_reporte == "ANUAL"):
             lista_dict_tipos_servicios_realizados = SERVICIO_CONTROLADOR.conteo_tipos_servicios_realizados_controlador(
                 indice_opcion_tipo_reporte = indice_opcion_tipo_reporte,
                 anio = anio
@@ -243,20 +241,22 @@ class ReporteServicios(ReporteBase):
         fecha_hasta: Optional[date] = None,
         anio: Optional[str] = None
     ):
-        if (indice_opcion_tipo_reporte == OPCIONES_TIPO_REPORTE[0]):
+        opcion_tipo_reporte = TiposReporte[f"{indice_opcion_tipo_reporte}"].name
+        
+        if (opcion_tipo_reporte == "MENSUAL"):
             lista_dict_servicios_realizados_x_departamento = SERVICIO_CONTROLADOR.conteo_servicios_realizados_x_departamento_controlador(
                 indice_opcion_tipo_reporte = indice_opcion_tipo_reporte,
                 mes_anio = mes_anio
             )
             
-        if (indice_opcion_tipo_reporte == OPCIONES_TIPO_REPORTE[1]):
+        if (opcion_tipo_reporte == "RANGO_FECHA"):
             lista_dict_servicios_realizados_x_departamento = SERVICIO_CONTROLADOR.conteo_servicios_realizados_x_departamento_controlador(
                 indice_opcion_tipo_reporte = indice_opcion_tipo_reporte,
                 fecha_desde = fecha_desde,
                 fecha_hasta = fecha_hasta
             )
             
-        if (indice_opcion_tipo_reporte == OPCIONES_TIPO_REPORTE[2]):
+        if (opcion_tipo_reporte == "ANUAL"):
             lista_dict_servicios_realizados_x_departamento = SERVICIO_CONTROLADOR.conteo_servicios_realizados_x_departamento_controlador(
                 indice_opcion_tipo_reporte = indice_opcion_tipo_reporte,
                 anio = anio
@@ -294,20 +294,22 @@ class ReporteServicios(ReporteBase):
         fecha_hasta: Optional[date] = None,
         anio: Optional[str] = None
     ):
-        if (indice_opcion_tipo_reporte == OPCIONES_TIPO_REPORTE[0]):
+        opcion_tipo_reporte = TiposReporte[f"{indice_opcion_tipo_reporte}"].name
+        
+        if (opcion_tipo_reporte == "MENSUAL"):
             lista_dict_tipos_servicios_realizados = SERVICIO_CONTROLADOR.conteo_tipos_servicios_realizados_controlador(
                 indice_opcion_tipo_reporte = indice_opcion_tipo_reporte,
                 mes_anio = mes_anio
             )
         
-        if (indice_opcion_tipo_reporte == OPCIONES_TIPO_REPORTE[1]):
+        if (opcion_tipo_reporte == "RANGO_FECHA"):
             lista_dict_tipos_servicios_realizados = SERVICIO_CONTROLADOR.conteo_tipos_servicios_realizados_controlador(
                 indice_opcion_tipo_reporte = indice_opcion_tipo_reporte,
                 fecha_desde = fecha_desde,
                 fecha_hasta = fecha_hasta
             )
         
-        if (indice_opcion_tipo_reporte == OPCIONES_TIPO_REPORTE[2]):
+        if (opcion_tipo_reporte == "ANUAL"):
             lista_dict_tipos_servicios_realizados = SERVICIO_CONTROLADOR.conteo_tipos_servicios_realizados_controlador(
                 indice_opcion_tipo_reporte = indice_opcion_tipo_reporte,
                 anio = anio
@@ -401,11 +403,13 @@ class ReporteServicios(ReporteBase):
                 bottom = tipo_borde
             )
             
+            opcion_tipo_reporte = TiposReporte[f"{INDICE_OPCION_TIPO_REPORTE}"].name
+            
             if (FECHA_DESDE and FECHA_HASTA):
                 FECHA_DESDE = FECHA_DESDE.strftime("%Y-%m-%d")
                 FECHA_HASTA = FECHA_HASTA.strftime("%Y-%m-%d")
             
-            if (INDICE_OPCION_TIPO_REPORTE == OPCIONES_TIPO_REPORTE[0]):
+            if (opcion_tipo_reporte == "MENSUAL"):
                 mes = cargar_mes(MES_ANIO).upper()
 
                 _, anio = MES_ANIO.split("-")
@@ -413,10 +417,10 @@ class ReporteServicios(ReporteBase):
                 
                 nombre_archivo = f"REPORTE SERVICIOS - {mes} {anio}"
             
-            if (INDICE_OPCION_TIPO_REPORTE == OPCIONES_TIPO_REPORTE[1]):
+            if (opcion_tipo_reporte == "RANGO_FECHA"):
                 nombre_archivo = f"REPORTE SERVICIOS - DESDE {FECHA_DESDE} HASTA {FECHA_HASTA}"
             
-            if (INDICE_OPCION_TIPO_REPORTE == OPCIONES_TIPO_REPORTE[2]):
+            if (opcion_tipo_reporte == "ANUAL"):
                 nombre_archivo = f"REPORTE SERVICIOS - {ANIO}"
             
             self.cargar_configuraciones_excel(hoja_1, hoja_2)
@@ -470,7 +474,8 @@ class ReporteServicios(ReporteBase):
                 ANIO
             )
             
-            RUTA_ARCHIVO_EXCEL = f"{self.RUTA_REPORTES_SERVICOS}/{nombre_archivo}.xlsx"
+            RUTA_REPORTES_SERVICOS = obtener_ruta_reportes(INDICE_OPCION_TIPO_REPORTE)
+            RUTA_ARCHIVO_EXCEL = f"{RUTA_REPORTES_SERVICOS}/{nombre_archivo}.xlsx"
             
             libro.save(RUTA_ARCHIVO_EXCEL)
             

--- a/src/ui/controladores/servicio_controlador.py
+++ b/src/ui/controladores/servicio_controlador.py
@@ -2,15 +2,9 @@ from dominio.entidades.servicio import Servicio
 from dominio.entidades.departamento import Departamento
 from dominio.entidades.tipo_servicio import TipoServicio
 from dominio.excepciones import ServicioValidacionError, DepartamentoValidacionError, TipoServicioValidacionError
+from utilidades.tipos_reporte import TiposReporte
 from datetime import date
 from typing import Optional
-
-
-OPCIONES_TIPO_REPORTE = {
-    "MENSUAL": 1,
-    "RANGO_FECHA": 2,
-    "ANUAL": 3
-}
 
 
 class ServicioControlador:
@@ -96,15 +90,15 @@ class ServicioControlador:
         anio: Optional[str] = None
     ):
         try:
-            opcion_tipo_reporte = OPCIONES_TIPO_REPORTE.get(indice_opcion_tipo_reporte)
+            opcion_tipo_reporte = TiposReporte[f"{indice_opcion_tipo_reporte}"].name
             
-            if (opcion_tipo_reporte == 1):
+            if (opcion_tipo_reporte == "MENSUAL"):
                 servicios = self.listar_servicios.obtener_por_mes_anio(mes_anio)
             
-            if (opcion_tipo_reporte == 2):
+            if (opcion_tipo_reporte == "RANGO_FECHA"):
                 servicios = self.listar_servicios.obtener_por_rango_fecha(fecha_desde, fecha_hasta)
             
-            if (opcion_tipo_reporte == 3):
+            if (opcion_tipo_reporte == "ANUAL"):
                 servicios = self.listar_servicios.obtener_por_anio(anio)
             
             lista_dict_servicios = []
@@ -173,15 +167,15 @@ class ServicioControlador:
         anio: Optional[str] = None
     ):
         try:
-            opcion_tipo_reporte = OPCIONES_TIPO_REPORTE.get(indice_opcion_tipo_reporte)
+            opcion_tipo_reporte = TiposReporte[f"{indice_opcion_tipo_reporte}"].name
             
-            if (opcion_tipo_reporte == 1):
+            if (opcion_tipo_reporte == "MENSUAL"):
                 conteo_servicios_realizados = self.listar_servicios.obtener_conteo_tipos_servicios_realizados(mes_anio)
             
-            if (opcion_tipo_reporte == 2):
+            if (opcion_tipo_reporte == "RANGO_FECHA"):
                 conteo_servicios_realizados = self.listar_servicios.obtener_conteo_tipos_servicios_realizados_por_rango_fecha(fecha_desde, fecha_hasta)
             
-            if (opcion_tipo_reporte == 3):
+            if (opcion_tipo_reporte == "ANUAL"):
                 conteo_servicios_realizados = self.listar_servicios.obtener_conteo_tipos_servicios_realizados_por_anio(anio)
             
             lista_dict_conteo_servicios_realizados = []
@@ -207,15 +201,15 @@ class ServicioControlador:
         anio: Optional[str] = None
     ):
         try:
-            opcion_tipo_reporte = OPCIONES_TIPO_REPORTE.get(indice_opcion_tipo_reporte)
+            opcion_tipo_reporte = TiposReporte[f"{indice_opcion_tipo_reporte}"].name
             
-            if (opcion_tipo_reporte == 1):
+            if (opcion_tipo_reporte == "MENSUAL"):
                 conteo_servicios_realizaods_x_departamento = self.listar_servicios.obtener_conteo_servicios_x_departamento(mes_anio)
             
-            if (opcion_tipo_reporte == 2):
+            if (opcion_tipo_reporte == "RANGO_FECHA"):
                 conteo_servicios_realizaods_x_departamento = self.listar_servicios.obtener_conteo_servicios_x_departamento_por_rango_fecha(fecha_desde, fecha_hasta)
             
-            if (opcion_tipo_reporte == 3):
+            if (opcion_tipo_reporte == "ANUAL"):
                 conteo_servicios_realizaods_x_departamento = self.listar_servicios.obtener_conteo_servicios_x_departamento_por_anio(anio)
             
             lista_dict_servicios_realizados_x_departamento = []

--- a/src/utilidades/tipos_reporte.py
+++ b/src/utilidades/tipos_reporte.py
@@ -1,0 +1,7 @@
+from enum import Enum
+
+
+class TiposReporte(Enum):
+    MENSUAL = "MENSUAL"
+    RANGO_FECHA = "POR RANGO DE FECHA"
+    ANUAL = "ANUAL"


### PR DESCRIPTION
- Ordenar los reportes generados por las siguientes carpetas: **MENSUAL**, **POR RANGO DE FECHA** y **ANUAL**.
- Se creó un archivo donde está un `Enum` para poder reutilizar los tipos de reportes y así utilizar tanto sus `name` como los `value` en distintas partes del proceso de generar los reportes.