### PR TITLE
Formatear fechas y ordenar las consultas pertinentes al realizar los reportes por la fecha del servicio

### DIFF
--- a/src/infraestructura/adaptadores/servicio_adaptador.py
+++ b/src/infraestructura/adaptadores/servicio_adaptador.py
@@ -101,7 +101,8 @@ class ServicioAdaptador(ServicioPuerto):
                 observaciones_adicionales
             FROM vw_servicios_prestados
             WHERE MONTH(fecha_servicio) = :mes
-            AND YEAR(fecha_servicio)  = :anio;
+            AND YEAR(fecha_servicio)  = :anio
+            ORDER BY fecha_servicio;
         """
         
         parametros = {
@@ -129,7 +130,8 @@ class ServicioAdaptador(ServicioPuerto):
                 nombres_tecnicos,
                 observaciones_adicionales
             FROM vw_servicios_prestados
-            WHERE fecha_servicio BETWEEN :fecha_desde AND :fecha_hasta;
+            WHERE fecha_servicio BETWEEN :fecha_desde AND :fecha_hasta
+            ORDER BY fecha_servicio;
         """
         
         parametros = {
@@ -159,7 +161,8 @@ class ServicioAdaptador(ServicioPuerto):
                 nombres_tecnicos,
                 observaciones_adicionales
             FROM vw_servicios_prestados
-            WHERE YEAR(fecha_servicio) = :anio;
+            WHERE YEAR(fecha_servicio) = :anio
+            ORDER BY fecha_servicio;
         """
         
         parametros = {"anio": anio}

--- a/src/infraestructura/reportes/reporte_servicios.py
+++ b/src/infraestructura/reportes/reporte_servicios.py
@@ -1,7 +1,7 @@
 import pandas as pd
 import matplotlib.pyplot as plt
 import xlwings as xw
-from datetime import date
+from datetime import date, datetime
 from openpyxl import Workbook
 from openpyxl.utils import get_column_letter
 from openpyxl.styles import Font, PatternFill, Alignment, Border, Side
@@ -330,7 +330,7 @@ class ReporteServicios(ReporteBase):
         ax.set_title("CONTEO DE SERVICIOS")
         ax.tick_params(
             axis = "x",
-            rotation = 45
+            rotation = 90
         )
         
         figura.tight_layout()
@@ -418,7 +418,13 @@ class ReporteServicios(ReporteBase):
                 nombre_archivo = f"REPORTE SERVICIOS - {mes} {anio}"
             
             if (opcion_tipo_reporte == "RANGO_FECHA"):
-                nombre_archivo = f"REPORTE SERVICIOS - DESDE {FECHA_DESDE} HASTA {FECHA_HASTA}"
+                FECHA_DESDE_DATE = datetime.strptime(FECHA_DESDE, "%Y-%m-%d")
+                FECHA_HASTA_DATE = datetime.strptime(FECHA_HASTA, "%Y-%m-%d")
+                
+                FECHA_DESDE_FORMATEADO = FECHA_DESDE_DATE.strftime("%d-%m-%Y")
+                FECHA_HASTA_FORMATEADO = FECHA_HASTA_DATE.strftime("%d-%m-%Y")
+                
+                nombre_archivo = f"REPORTE SERVICIOS - DESDE {FECHA_DESDE_FORMATEADO} HASTA {FECHA_HASTA_FORMATEADO}"
             
             if (opcion_tipo_reporte == "ANUAL"):
                 nombre_archivo = f"REPORTE SERVICIOS - {ANIO}"

--- a/src/ui/controladores/servicio_controlador.py
+++ b/src/ui/controladores/servicio_controlador.py
@@ -107,13 +107,15 @@ class ServicioControlador:
                 return []
             
             for servicio in servicios:
+                fecha_servicio_formateada = servicio[5].strftime("%d-%m-%Y")
+                
                 elemento = {
                     "servicio_id": servicio[0],
                     "departamento_id": servicio[1],
                     "tipo_servicio_id": servicio[2],
                     "nombre_departamento": servicio[3],
                     "mes_anio": servicio[4],
-                    "fecha_servicio": servicio[5],
+                    "fecha_servicio": fecha_servicio_formateada,
                     "falla_presenta": servicio[6],
                     "tipo_servicio_prestado": servicio[7],
                     "nombres_tecnicos": servicio[8],
@@ -140,12 +142,14 @@ class ServicioControlador:
                 return []
             
             for servicio in servicios:
+                fecha_servicio_formateada = servicio[4].strftime("%d-%m-%Y")
+                
                 elemento = {
                     "servicio_id": servicio[0],
                     "departamento_id": servicio[1],
                     "tipo_servicio_id": servicio[2],
                     "nombre_departamento": servicio[3],
-                    "fecha_servicio": servicio[4],
+                    "fecha_servicio": fecha_servicio_formateada,
                     "falla_presenta": servicio[5],
                     "tipo_servicio_prestado": servicio[6],
                     "nombres_tecnicos": servicio[7],

--- a/src/ui/ventanas/ventanas_python/ventanas_info/VentanaInfoServicio.py
+++ b/src/ui/ventanas/ventanas_python/ventanas_info/VentanaInfoServicio.py
@@ -2,6 +2,7 @@ from PyQt5.QtWidgets import QDialog, QMessageBox, QCompleter
 from PyQt5.QtCore import Qt
 from ui.ventanas.ventanas_pyuic.VentanaInfoServicioPyuic import Ui_ventanaInfoServicio
 from typing import Dict
+from datetime import datetime
 from dominio.excepciones import ServicioValidacionError, DepartamentoValidacionError, TipoServicioValidacionError
 
 
@@ -30,8 +31,11 @@ class VentanaInfoServicio(QDialog, Ui_ventanaInfoServicio):
         self.botonEliminarServicio.clicked.connect(self.eliminar_servicio)
         self.botonCancelar.clicked.connect(self.reject)
     
-    def cargar_datos(self): 
-        self.deInfoFechaServicio.setDate(self.servicio_data["fecha_servicio"])
+    def cargar_datos(self):
+        fecha_servicio_str = self.servicio_data["fecha_servicio"]
+        fecha_servicio_date = datetime.strptime(fecha_servicio_str, "%d-%m-%Y").date()
+        
+        self.deInfoFechaServicio.setDate(fecha_servicio_date)
         self.inputInfoNombreDepartamento.setText(self.servicio_data["nombre_departamento"])
         self.inputInfoFallaPresenta.setText(self.servicio_data["falla_presenta"])
         self.inputInfoServicioPrestado.setText(self.servicio_data["tipo_servicio_prestado"])

--- a/src/ui/ventanas/ventanas_python/ventanas_principales/VentanaApp.py
+++ b/src/ui/ventanas/ventanas_python/ventanas_principales/VentanaApp.py
@@ -9,6 +9,7 @@ from dominio.excepciones import ServicioValidacionError, DepartamentoValidacionE
 from infraestructura.conexiones.respaldo import RespaldoLocal
 from infraestructura.reportes.reporte_servicios import ReporteServicios
 from typing import Dict
+from datetime import datetime
 from pathlib import Path
 
 
@@ -209,12 +210,17 @@ class VentanaApp:
                 
             for fila, servicio in enumerate(servicios):
                 observacion_adicional = servicio["observaciones_adicionales"]
+                
+                fecha_servicio_str = servicio["fecha_servicio"]
+                fecha_servicio_date = datetime.strptime(fecha_servicio_str, "%d-%m-%Y").date()
+                fecha_servicio_formateada = fecha_servicio_date.strftime("%d-%m-%Y")
+                
                 if (self.esta_vacio(observacion_adicional)):
                     observacion_adicional = ""
                 
                 items = [
                     QStandardItem(str(servicio["nombre_departamento"])),
-                    QStandardItem(str(servicio["fecha_servicio"])),
+                    QStandardItem(fecha_servicio_formateada),
                     QStandardItem(str(servicio["falla_presenta"])),
                     QStandardItem(str(servicio["tipo_servicio_prestado"])),
                     QStandardItem(str(servicio["nombres_tecnicos"])),

--- a/src/ui/ventanas/ventanas_python/ventanas_principales/VentanaApp.py
+++ b/src/ui/ventanas/ventanas_python/ventanas_principales/VentanaApp.py
@@ -211,16 +211,12 @@ class VentanaApp:
             for fila, servicio in enumerate(servicios):
                 observacion_adicional = servicio["observaciones_adicionales"]
                 
-                fecha_servicio_str = servicio["fecha_servicio"]
-                fecha_servicio_date = datetime.strptime(fecha_servicio_str, "%d-%m-%Y").date()
-                fecha_servicio_formateada = fecha_servicio_date.strftime("%d-%m-%Y")
-                
                 if (self.esta_vacio(observacion_adicional)):
                     observacion_adicional = ""
                 
                 items = [
                     QStandardItem(str(servicio["nombre_departamento"])),
-                    QStandardItem(fecha_servicio_formateada),
+                    QStandardItem(str(servicio["fecha_servicio"])),
                     QStandardItem(str(servicio["falla_presenta"])),
                     QStandardItem(str(servicio["tipo_servicio_prestado"])),
                     QStandardItem(str(servicio["nombres_tecnicos"])),


### PR DESCRIPTION
- Se formateó las fechas para que se mostraran como `día-mes-año`.
- Se ordenó las consultas por la fecha del servicio.